### PR TITLE
Added Editorial Author Subtitle

### DIFF
--- a/components/Problemset/index.tsx
+++ b/components/Problemset/index.tsx
@@ -210,7 +210,7 @@ export const Problemset = ({ problems }: ProblemsetProps) => {
           <Text p={1}align="left" typography="display.small">Problem Viewer{problem && `: ${problem.display}`}</Text>
           <Text p={1}align="left" typography={"title.small"} marginTop={"-1.5vh"}>
             {problem && `Editorial Author`}
-            {problem && `${(problem.editorialAuthors.length === 1) ? "" : "s"} : ${problem.editorialAuthors.join(", ")}`}
+            {problem && `${(problem.editorialAuthors.length === 1) ? "" : "s"}: ${problem.editorialAuthors.join(", ")}`}
           </Text>
           <VStack overflowY="auto" alignItems="start">
             <Box pr={4} maxW="full">

--- a/components/Problemset/index.tsx
+++ b/components/Problemset/index.tsx
@@ -208,7 +208,10 @@ export const Problemset = ({ problems }: ProblemsetProps) => {
       >
         <VStack maxWidth="full" spacing={1} h="65vh" alignItems="left">
           <Text p={1}align="left" typography="display.small">Problem Viewer{problem && `: ${problem.display}`}</Text>
-          <Text p={1}align="left" typography={"title.small"} marginTop={"-1.5vh"}>Editorial Author{problem && `${(problem.editorialAuthors.length === 1) ? "" : "s"} : ${problem.editorialAuthors.join(", ")}`}</Text>
+          <Text p={1}align="left" typography={"title.small"} marginTop={"-1.5vh"}>
+            {problem && `Editorial Author`}
+            {problem && `${(problem.editorialAuthors.length === 1) ? "" : "s"} : ${problem.editorialAuthors.join(", ")}`}
+          </Text>
           <VStack overflowY="auto" alignItems="start">
             <Box pr={4} maxW="full">
               {

--- a/components/Problemset/index.tsx
+++ b/components/Problemset/index.tsx
@@ -208,6 +208,7 @@ export const Problemset = ({ problems }: ProblemsetProps) => {
       >
         <VStack maxWidth="full" spacing={1} h="65vh" alignItems="left">
           <Text p={1}align="left" typography="display.small">Problem Viewer{problem && `: ${problem.display}`}</Text>
+          <Text p={1}align="left" typography={"title.small"} marginTop={"-1.5vh"}>Editorial Author{problem && `${(problem.editorialAuthors.length === 1) ? "" : "s"} : ${problem.editorialAuthors.join(", ")}`}</Text>
           <VStack overflowY="auto" alignItems="start">
             <Box pr={4} maxW="full">
               {


### PR DESCRIPTION
### Now shows the author as part of the title
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/d2752100-9f4d-464f-aab7-700f0a07c624">




### still at the top when scroll
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/c7db5339-c249-4555-9dee-4921097ca95c">





### "author" becomes "authors" if multiple 
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/7a2a6d66-b52d-4a7d-bb72-ea2661d5a391">





# **ONLY TO BE REVIEWED BY DEVS (vlad, boris)**
(tho other people's opinions will be appreciated)