### PR TITLE
Create sitemap.ts

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+ 
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://www.britishinformatics.org/',
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 1,
+    },
+    {
+      url: 'https://www.britishinformatics.org/bio1',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: 'https://www.britishinformatics.org/bio2',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+  ]
+}


### PR DESCRIPTION
For the website to be published to Google Search, the owner needs to register it on Google Search Console and include the corresponding sitemap, an XML file containing metadata on the website's pages. With the addition of `sitemap.ts`, a `sitemap.xml` file should be generated when the website is deployed, where it can be retrieved with the URL `https://www.britishinformatics.org/sitemap.xml`.

@myst-6 the instructions for adding the site to Google Search Console can be found [here](https://ahrefs.com/blog/submit-website-to-google/). Once it is registered and indexed, I can work to improve its SEO.